### PR TITLE
QIITA_API_TOKENが設定されてない時はqiitaオフ

### DIFF
--- a/server.deno.js
+++ b/server.deno.js
@@ -18,7 +18,7 @@ Deno.serve(async (req) => {
 
   //クエリパラメータを取得
   const param = new URL(req.url).searchParams;
-  const qiita = param.get("qiita") === "0" ? false : true;
+  const qiita = param.get("qiita") === "0" || !Deno.env.get("QIITA_API_TOKEN") ? false : true;
   const zenn = param.get("zenn") === "0" ? false : true;
   const issou = param.get("issou") === "0" ? false : true;
   const keyWord = param.get("q") || "";


### PR DESCRIPTION
## 概要

QIITA_API_TOKENを取得しなくても動かしたい！

## 関連

https://github.com/jigintern/real-2024-c/issues/73

## テスト方法

QIITA_API_TOKEN なしで起動してQiita記事なしで動くことを確認

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
