### PR TITLE
川UI修正

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,7 +53,7 @@
       <div id="create-river">
         <button id="create-river-btn">川</button>
         <button type="submit" id="create-river-ok">選択した記事を確定する</button>
-        <button type="button" id="create-river-cancel"></button>
+        <button type="button" id="create-river-cancel">キャンセル</button>
       </div>
     </main>
     <footer></footer>

--- a/public/script.js
+++ b/public/script.js
@@ -268,6 +268,8 @@ globalThis.onload = async () => {
                 createRiver = false;
                 const url = await riverId("", riverArticles);
                 prompt("共有URL", url);
+                chooseOkBtn.style.visibility = 'hidden';
+                createCancel.style.visibility = 'hidden';
             })
 
 
@@ -275,13 +277,17 @@ globalThis.onload = async () => {
             createCancel.style.visibility = 'visible';
             createCancel.addEventListener('click', () => {
                 createRiver = false;
-                articleLinks = [];
+                articleLinks.length = 0;
+                chooseOkBtn.style.visibility = 'hidden';
+                createCancel.style.visibility = 'hidden';
             })
             
         // 通常モード
         } else {
             console.log("Mode: See");
             createRiver = false;
+            chooseOkBtn.style.visibility = 'hidden';
+            createCancel.style.visibility = 'hidden';
 
             const articleLinks = document.querySelectorAll(".article-link");
             for (const articleLink of articleLinks) {

--- a/public/script.js
+++ b/public/script.js
@@ -243,7 +243,7 @@ globalThis.onload = async () => {
     const createCancel = document.getElementById('create-river-cancel');
 
     // モードの切り替え
-    changeModeBtn.addEventListener('click', () => {
+    changeModeBtn.onclick = () => {
         // 川の作成モード
         if (createRiver === false) {
             console.log("Mode: Choose");
@@ -256,31 +256,31 @@ globalThis.onload = async () => {
             
             const feedItems = document.querySelectorAll(".feed-item");
             for (const feedItem of feedItems) {
-                feedItem.addEventListener('click', () => {
+                feedItem.onclick = () => {
                     // リストに保存しておく
                     saveArticle(feedItem);
-                })
+                };
             }
 
             // リストの確定
             chooseOkBtn.style.visibility = 'visible';
-            chooseOkBtn.addEventListener('click', async () => {
+            chooseOkBtn.onclick = async () => {
                 createRiver = false;
                 const url = await riverId("", riverArticles);
                 prompt("共有URL", url);
                 chooseOkBtn.style.visibility = 'hidden';
                 createCancel.style.visibility = 'hidden';
-            })
+            };
 
 
             // キャンセル
             createCancel.style.visibility = 'visible';
-            createCancel.addEventListener('click', () => {
+            createCancel.onclick = () => {
                 createRiver = false;
                 articleLinks.length = 0;
                 chooseOkBtn.style.visibility = 'hidden';
                 createCancel.style.visibility = 'hidden';
-            })
+            };
             
         // 通常モード
         } else {
@@ -294,7 +294,7 @@ globalThis.onload = async () => {
                 articleLink.style.pointerEvents = "auto";
             }
         }
-    });
+    };
 };
 
 let zIndex = 998;

--- a/public/style.css
+++ b/public/style.css
@@ -270,4 +270,8 @@ input[type=checkbox]:checked + .checkbox-icon {
 }
 #create-river-cancel {
   visibility: hidden;
+  position: fixed;
+  top: 110px;
+  left: 10px;
+  padding: 10px;
 }/*# sourceMappingURL=style.css.map */

--- a/server.deno.js
+++ b/server.deno.js
@@ -18,7 +18,7 @@ Deno.serve(async (req) => {
 
   //クエリパラメータを取得
   const param = new URL(req.url).searchParams;
-  const qiita = param.get("qiita") === "0" ? false : true;
+  const qiita = param.get("qiita") === "0" || !Deno.env.get("QIITA_API_TOKEN") ? false : true;
   const zenn = param.get("zenn") === "0" ? false : true;
   const issou = param.get("issou") === "0" ? false : true;
   const keyWord = param.get("q") || "";


### PR DESCRIPTION
## 概要

川UIの挙動を修正

- 川UIを visibility = "hidden" で閉じるコードを追加
- addEventListerだとコールバックがどんどん増えちゃうので、onclickで設定
- キャンセル時、articleLinks = [] で定数代入エラーが起きるので、articleLinks.length = 0 でクリア

## 関連

https://github.com/jigintern/real-2024-c/issues/72

## テスト方法

- [x] 川ボタンを押して選択とキャンセルがでる
- [x] もう一度川ボタンを押して選択とキャンセルが消える
- [x] 選択ボタンを押して共有ダイアログがでる
- [x] 再度、川ボタン、選択ボタンを押して共有ダイアログが1回だけ出る

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
